### PR TITLE
TimeKeep should be a privileged system module

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -13,6 +13,7 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 LOCAL_PACKAGE_NAME := TimeKeep
 LOCAL_CERTIFICATE := platform
+LOCAL_PRIVILEGED_MODULE := true
 
 LOCAL_PROGUARD_ENABLED := disabled
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.sony.timekeep"
+    coreApp="true"
+    android:sharedUserId="android.uid.system"
     android:versionCode="1"
     android:versionName="1.0" >
 


### PR DESCRIPTION
TimeKeep's sole purpose in life is to update 'persist.sys.timeadjust'
so TimeKeep needs to be a privileged system module. This change is
necessary for a sane SELinux policy.
