### PR TITLE
timekeep: fix header include

### DIFF
--- a/timekeep.c
+++ b/timekeep.c
@@ -30,6 +30,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <fcntl.h>
 
 #include <sys/time.h>


### PR DESCRIPTION
it is required for memset during karin build process

Signed-off-by: Humberto Borba humberos@gmail.com
