### PR TITLE
timekeep: Add liblog as shared library dependency

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -3,7 +3,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := timekeep.c
 LOCAL_MODULE := timekeep
-LOCAL_SHARED_LIBRARIES := libcutils
+LOCAL_SHARED_LIBRARIES := libcutils liblog
 LOCAL_MODULE_TAGS := optional
 include $(BUILD_EXECUTABLE)
 


### PR DESCRIPTION
fixes

hardware/sony/timekeep/timekeep.c:65: error: undefined reference to '__android_log_print'
hardware/sony/timekeep/timekeep.c:55: error: undefined reference to '__android_log_print'
hardware/sony/timekeep/timekeep.c:89: error: undefined reference to '__android_log_print'
hardware/sony/timekeep/timekeep.c:115: error: undefined reference to '__android_log_print'

Signed-off-by: David Viteri <davidteri91@gmail.com>