### PR TITLE
Remove not needed file permission change

### DIFF
--- a/timekeep.c
+++ b/timekeep.c
@@ -74,15 +74,11 @@ int read_epoch(unsigned long* epoch) {
 
 void restore_ats(unsigned long value) {
 	FILE *fp = NULL;
-	char mode[] = "0777";
-	int i;
 
-	i = strtol(mode, 0, 8);
 	value *= 1000;
 	fp = fopen(RTC_ATS_FILE, "wb");
 
 	if (fp != NULL) {
-		chmod(RTC_ATS_FILE, i);
 		fwrite(&value, sizeof(value), 1, fp);
 		fclose(fp);
 	} else {


### PR DESCRIPTION
Setting the permission on the ats_2 file to 0777 is bad since we should not write executable files to /data. With this current functionality timekeep requires invasive sepolicy, such as fowner and fsetid.

Changing the permissions on this file is actually not necessary since timekeep is run as root, and the default owner of ats_2 is root with file permissions of 0600. This is actually sufficient for the timekeep functionality, for both the C and Java parts.

With this patch we can set saner sepolicy for timekeep.

Tested on suzu, confirming the functionality of both timekeep (C) and TimeKeep (Java) services.