### PR TITLE
Timekeep: set LOCAL_SDK_VERSION to current

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,6 +1,6 @@
 LOCAL_PATH:= $(call my-dir)
-include $(CLEAR_VARS)
 
+include $(CLEAR_VARS)
 LOCAL_SRC_FILES := timekeep.c
 LOCAL_MODULE := timekeep
 LOCAL_SHARED_LIBRARIES := libcutils liblog
@@ -13,13 +13,13 @@ endif
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
-
 LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 LOCAL_PACKAGE_NAME := TimeKeep
 LOCAL_CERTIFICATE := platform
 LOCAL_PRIVILEGED_MODULE := true
-
+ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 28 ))" )))
+LOCAL_SDK_VERSION := current
+endif
 LOCAL_PROGUARD_ENABLED := disabled
-
 include $(BUILD_PACKAGE)


### PR DESCRIPTION
to avoid build problems in android pie

Signed-off-by: David Viteri <davidteri91@gmail.com>