### PR TITLE
Let TimeKeep use private platform APIs

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -17,9 +17,7 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 LOCAL_PACKAGE_NAME := TimeKeep
 LOCAL_CERTIFICATE := platform
+LOCAL_PRIVATE_PLATFORM_APIS := true
 LOCAL_PRIVILEGED_MODULE := true
-ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 28 ))" )))
-LOCAL_SDK_VERSION := current
-endif
 LOCAL_PROGUARD_ENABLED := disabled
 include $(BUILD_PACKAGE)


### PR DESCRIPTION
* /we/ tried to fix it before by setting
  LOCAL_SDK_VERSION := current but apparently
  no one tested if it actually compiled.
* Setting LOCAL_PRIVATE_PLATFORM_APIS := true makes
  it compile properly as the package depends on
  private APIs such as android.os.SystemProperties.
* Lets also remove unnecessary version filter while
  at it. There's literally no reason to ever do that.

Change-Id: I795d6c647568be1c802e609d8ff93759da3873bd