### PR TITLE
timekeep.rc: Drop root privileges

### DIFF
--- a/vendor/etc/init/timekeep.rc
+++ b/vendor/etc/init/timekeep.rc
@@ -8,7 +8,8 @@ on boot
 # Time service
 service timekeep /vendor/bin/timekeep restore
     class late_start
-    user root
-    group root system
+    user system
+    group system
+    capabilities SYS_TIME
     oneshot
     writepid /dev/cpuset/system-background/tasks


### PR DESCRIPTION
timekeep can run under the system user as long as it possesses CAP_SYS_TIME.

<strike>The additional chown statements aid in the transition from root-created/-owned files in /data/*.
(TODO: Check if they are really necessary)</strike>
-> Not necessary, dropped