### PR TITLE
[WIP] Use persist.vendor.timeadjust for prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ACTION_TIME_CHANGED, ACTION_TIMEZONE_CHANGED and ACTION_SHUTDOWN and then calls 
 
 When the Java broadcastreceiver gets one of the above intents, timekeep is called with
 store parameter and the time delta between the set date (in seconds) and 
-/sys/class/rtc/rtc0/since_epoch is stored to a persistent property (persist.sys.timeadjust).
+/sys/class/rtc/rtc0/since_epoch is stored to a persistent property (persist.vendor.timeadjust).
 
 To restore the time timekeep is called with the restore parameter. The persistent property
 containing the time delta is then read together with the since_epoch value and settimeofday

--- a/src/com/sony/timekeep/TimeKeep.java
+++ b/src/com/sony/timekeep/TimeKeep.java
@@ -50,7 +50,7 @@ import android.os.SystemProperties;
 
 public class TimeKeep extends BroadcastReceiver {
 	private static final String TAG = "TimeKeep-Receiver";
-	private static final String TIMEADJ_PROP = "persist.sys.timeadjust";
+	private static final String TIMEADJ_PROP = "persist.vendor.timeadjust";
 	private static final String RTC_SINCE_EPOCH = "/sys/class/rtc/rtc0/since_epoch";
 	private static final String RTC_ATS_FILE = android.os.Build.VERSION.SDK_INT >= 26 ?
 		"/data/vendor/time/ats_2" : "/data/time/ats_2";

--- a/timekeep.c
+++ b/timekeep.c
@@ -49,7 +49,7 @@
 #else
 #define RTC_ATS_FILE "/data/time/ats_2"
 #endif
-#define TIME_ADJUST_PROP "persist.sys.timeadjust"
+#define TIME_ADJUST_PROP "persist.vendor.timeadjust"
 
 int read_epoch(unsigned long* epoch) {
 	int res = 0;


### PR DESCRIPTION
This is needed to fulfil Android's new requirements for "compatible" properties.