### PR TITLE
timekeep: Ensure ats_2 file is always 8 bytes.

### DIFF
--- a/timekeep.c
+++ b/timekeep.c
@@ -40,7 +40,11 @@
 #define LOG_TAG "TimeKeep"
 
 #include <cutils/properties.h>
+#if ANDROID_SDK_VERSION >= 26
+#include <log/log.h>
+#else
 #include <cutils/log.h>
+#endif
 #include <errno.h>
 
 #define RTC_SYS_FILE "/sys/class/rtc/rtc0/since_epoch"


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/timekeep/issues/23

`long` on 32-bit platforms is generally 4 bytes long instead of 8 on
64-bit platforms. Use uint64_t to ensure it is always exactly 8 bytes.

For consistency convert the other variables to `unsigned long long`,
which is guaranteed to hold _at least_ a 64-bit number regardless of the
target architecture.

@ArianK16a can you validate that this works for you?