### PR TITLE
timekeep: Make sure we have a /data before mucking with /data

### DIFF
--- a/vendor/etc/init/timekeep.rc
+++ b/vendor/etc/init/timekeep.rc
@@ -1,12 +1,13 @@
 on boot
+    # Set system as owner of RTC node
+    chown system system /sys/class/rtc/rtc0/since_epoch
+
+on post-fs-data
     # Create folder for timekeep
     mkdir /data/time 0770 system system
     mkdir /data/vendor/time 0770 system system
     chmod 0770 /data/time/ats_2
     chmod 0770 /data/vendor/time/ats_2
-
-    # Set system as owner of RTC node
-    chown system system /sys/class/rtc/rtc0/since_epoch
 
 # Time service
 service timekeep /vendor/bin/timekeep restore


### PR DESCRIPTION
* On FDE devices, in particular, /data isn't guaranteed to be mounted
  when the boot trigger fires

Change-Id: Id3ab06bcf06cf445313cd9843e77bf0851a304b7