### PR TITLE
[R] TimeKeep: Replace `SystemProperties` private API with `sysprop` definition

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -19,8 +19,9 @@ include $(CLEAR_VARS)
 LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 LOCAL_PACKAGE_NAME := TimeKeep
+LOCAL_STATIC_JAVA_LIBRARIES := SonyTimekeepProperties
 LOCAL_CERTIFICATE := platform
-LOCAL_PRIVATE_PLATFORM_APIS := true
+LOCAL_SDK_VERSION := current
 LOCAL_PRIVILEGED_MODULE := true
 LOCAL_PROGUARD_ENABLED := disabled
 ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28),)

--- a/src/com/sony/timekeep/TimeKeep.java
+++ b/src/com/sony/timekeep/TimeKeep.java
@@ -46,11 +46,11 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
-import android.os.SystemProperties;
+
+import com.sony.timekeep.SonyTimekeepProperties;
 
 public class TimeKeep extends BroadcastReceiver {
 	private static final String TAG = "TimeKeep-Receiver";
-	private static final String TIMEADJ_PROP = "persist.vendor.timeadjust";
 	private static final String RTC_SINCE_EPOCH = "/sys/class/rtc/rtc0/since_epoch";
 	private static final String RTC_ATS_FILE = android.os.Build.VERSION.SDK_INT >= 26 ?
 		"/data/vendor/time/ats_2" : "/data/time/ats_2";
@@ -63,10 +63,8 @@ public class TimeKeep extends BroadcastReceiver {
 		long epoch_since = readEpoch();
 		seconds -= epoch_since;
 
-		String currentAdjust = SystemProperties.get(TIMEADJ_PROP);
-
 		Log.d(TAG, "Setting adjust property to " + seconds);
-		SystemProperties.set(TIMEADJ_PROP, Long.toString(seconds));
+		SonyTimekeepProperties.timeadjust(Long.toString(seconds));
 		writeATS(seconds);
 	}
 

--- a/sysprop/Android.bp
+++ b/sysprop/Android.bp
@@ -1,0 +1,8 @@
+sysprop_library {
+    name: "SonyTimekeepProperties",
+    proprietary: true,
+
+    srcs: ["SonyTimekeepProperties.sysprop"],
+
+    property_owner: "Vendor",
+}

--- a/sysprop/SonyTimekeepProperties.sysprop
+++ b/sysprop/SonyTimekeepProperties.sysprop
@@ -1,0 +1,10 @@
+module: "com.sony.timekeep.SonyTimekeepProperties"
+owner: Vendor
+
+prop {
+    api_name: "timeadjust"
+    type: String
+    scope: Internal
+    access: ReadWrite
+    prop_name: "persist.vendor.timeadjust"
+}


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/837, CC @mlehtima to test this for me please :pray:

Using `android.os.SystemProperties` requires access to Android private platform APIs which is incompatible with specifying an SDK version.  Opting in to private APIs is largely unnecessary when the _vendor-specific_ system property can be accessed through a generated `sysprop` library.

Unfortunately these libraries are not available to C code, only to C++, so we'll keep using the hardcoded property name in `timekeep.c`.
